### PR TITLE
Fix typo on from "uses" to "users"

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -16,7 +16,7 @@ if (window.location.hostname == 'zedruc.net') {
 if (window?.navigator?.userAgent.toLowerCase().includes('firefox')) {
   notificationQueue.queue({
     title: 'Important!',
-    html: `It seems you are using a browser like Firefox, which doesn't support features required for this program to function properly.<br/><b>Firefox uses may increasingly experience issues with the suite thinking you are still logged in because of Firefox not closing connections properly.</b><br/> Consider using Chrome, as this is what the ATC24-Suite was developed for.`,
+    html: `It seems you are using a browser like Firefox, which doesn't support features required for this program to function properly.<br/><b>Firefox users may increasingly experience issues with the suite thinking you are still logged in because of Firefox not closing connections properly.</b><br/> Consider using Chrome, as this is what the ATC24-Suite was developed for.`,
     icon: 'info',
   });
 }


### PR DESCRIPTION
## Changed a typo meant for the alert shown to Firefox users about compatibility issues with said browser.

![image](https://github.com/user-attachments/assets/8d02cabf-1e58-4fe6-9844-3381634c3df8)
